### PR TITLE
feat: 에피그램 만들기, 수정하기 기능 구현

### DIFF
--- a/public/locales/en/editor.json
+++ b/public/locales/en/editor.json
@@ -1,0 +1,15 @@
+{
+  "title": "Create Epigram",
+  "content": "Content",
+  "content_placeholder": "Please enter within 500 characters.",
+  "author": "Author",
+  "enter_directly": "Enter directly",
+  "unknown": "Unknown",
+  "self": "Self",
+  "author_placeholder": "Enter author name",
+  "source": "Source",
+  "source_placeholder": "Enter source title",
+  "tag": "Tag",
+  "tag_placeholder": "Enter a tag (up to 10 characters)",
+  "submit": "Completed"
+}

--- a/public/locales/ko/editor.json
+++ b/public/locales/ko/editor.json
@@ -1,0 +1,15 @@
+{
+  "title": "에피그램 만들기",
+  "content": "내용",
+  "content_placeholder": "500자 이내로 입력해주세요.",
+  "author": "저자",
+  "enter_directly": "직접 입력",
+  "unknown": "알 수 없음",
+  "self": "본인",
+  "author_placeholder": "저자 이름 입력",
+  "source": "출처",
+  "source_placeholder": "출처 제목 입력",
+  "tag": "태그",
+  "tag_placeholder": "입력하여 태그 작성 (최대 10자)",
+  "submit": "작성 완료"
+}

--- a/src/components/Radio/index.tsx
+++ b/src/components/Radio/index.tsx
@@ -1,0 +1,21 @@
+type RadioProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+const Radio = (props: RadioProps) => {
+  return (
+    <input
+      type="radio"
+      {...props}
+      className="appearance-none h-5 w-5 mr-2
+      rounded-full border-[2px] border-blue-300 checked:bg-white
+      relative
+      before:content-[''] before:absolute 
+      before:inset-1 before:rounded-full 
+      before:bg-blue-800 before:scale-0
+      checked:before:scale-100
+      cursor-pointer
+      transition"
+    />
+  );
+};
+
+export default Radio;

--- a/src/components/RadioGroup/index.tsx
+++ b/src/components/RadioGroup/index.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import Radio from '../Radio';
+
+type Option = { label: string; value: string; disabled?: boolean };
+
+type RadioGroupProps = {
+  name: string;
+  options: Option[];
+  value: string;
+  onChange: (value: string) => void;
+  className?: string;
+};
+
+const RadioGroup = ({ name, options, value, onChange, className = '' }: RadioGroupProps) => {
+  return (
+    <fieldset className={className}>
+      <div className="flex flex-row gap-4 mb-3 lg:mb-4">
+        {options.map((opt) => (
+          <label key={opt.value} className="inline-flex items-center cursor-pointer">
+            <Radio
+              name={name}
+              value={opt.value}
+              checked={value === opt.value}
+              onChange={(e) => onChange(e.target.value)}
+              disabled={opt.disabled}
+            />
+            {opt.label}
+          </label>
+        ))}
+      </div>
+    </fieldset>
+  );
+};
+
+export default RadioGroup;

--- a/src/components/TagInput/index.tsx
+++ b/src/components/TagInput/index.tsx
@@ -1,0 +1,110 @@
+import React, { useEffect, useState } from 'react';
+import Input from '../Input';
+import { useTranslation } from 'next-i18next';
+
+type TagInputProps = {
+  onChangeTags?: (tags: string[]) => void;
+  initialTags?: string[];
+};
+
+const TagInput = ({ onChangeTags, initialTags }: TagInputProps) => {
+  const { t } = useTranslation('editor');
+  const [tags, setTags] = useState<string[]>([]);
+  const [draft, setDraft] = useState('');
+  const [isComposing, setIsComposing] = useState(false);
+
+  useEffect(() => {
+    if (initialTags) setTags(initialTags);
+  }, [initialTags]);
+
+  useEffect(() => {
+    onChangeTags?.(tags);
+  }, [tags, onChangeTags]);
+
+  const add = (raw: string) => {
+    if (tags.length >= 3) return;
+    const t = raw.trim();
+    if (!t) return;
+    if (t.length > 10) return;
+    if (tags.includes(t)) return;
+    setTags((prev) => [...prev, t]);
+    setDraft('');
+  };
+
+  const removeAt = (i: number) => {
+    setTags((prev) => prev.filter((_, idx) => idx !== i));
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (isComposing) return;
+
+    if (tags.length >= 3) {
+      e.preventDefault();
+      return;
+    }
+
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault();
+      add(draft);
+      return;
+    }
+
+    if (e.key === ',') {
+      e.preventDefault();
+    }
+  };
+
+  const onChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value;
+
+    if (isComposing) {
+      setDraft(val);
+      return;
+    }
+
+    const chunks = val.split(/[\n,]+/).map((s) => s.trim());
+    if (chunks.length === 1) {
+      setDraft(chunks[0]);
+      return;
+    }
+
+    const last = chunks.pop() ?? '';
+    chunks.filter(Boolean).forEach(add);
+    setDraft(last);
+  };
+
+  const disabled = tags.length >= 3;
+
+  return (
+    <div>
+      <Input
+        value={draft}
+        onChange={onChangeInput}
+        onCompositionStart={() => setIsComposing(true)}
+        onCompositionEnd={() => setIsComposing(false)}
+        onKeyDown={onKeyDown}
+        disabled={disabled}
+        maxLength={10}
+        placeholder={t('tag_placeholder')}
+      />
+      {tags.map((t, i) => (
+        <span
+          key={`${t}-${i}`}
+          className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-3 py-1 text-sm text-blue-800"
+        >
+          #{t}
+          <button
+            type="button"
+            className="px-1 text-blue-500 hover:text-blue-700"
+            onClick={() => removeAt(i)}
+            aria-label={`${t} 태그 삭제`}
+          >
+            ×
+          </button>
+        </span>
+      ))}
+    </div>
+  );
+};
+
+export default TagInput;

--- a/src/pages/editor.tsx
+++ b/src/pages/editor.tsx
@@ -1,0 +1,251 @@
+import Button from '@/components/Button';
+import Input from '@/components/Input';
+import RadioGroup from '@/components/RadioGroup';
+
+import { GetStaticProps } from 'next';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18NextConfig from '../../next-i18next.config';
+import { useTranslation } from 'next-i18next';
+import { EpigramForm, EpigramRequestApi } from '@/type/feed';
+import { Controller, useForm } from 'react-hook-form';
+import axiosInstance from '@/api/axiosInstance';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import TagInput from '@/components/TagInput';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/router';
+import { toTagNames } from '@/utils/tags';
+
+export const getStaticProps: GetStaticProps = async ({ locale }) => ({
+  props: {
+    ...(await serverSideTranslations(locale ?? 'ko', ['editor'], nextI18NextConfig)),
+  },
+});
+
+const FeedForm = () => {
+  const {
+    register,
+    watch,
+    control,
+    handleSubmit,
+    formState: { errors, isValid },
+    setValue,
+    reset,
+  } = useForm<EpigramForm>({
+    mode: 'onChange',
+    reValidateMode: 'onChange',
+    shouldUnregister: true,
+    defaultValues: {
+      content: '',
+      author: '',
+      referenceTitle: '',
+      referenceUrl: '',
+    },
+  });
+  const router = useRouter();
+  const epigramId = useMemo(() => {
+    const q = router.query.id;
+    return Array.isArray(q) ? q[0] : q;
+  }, [router.query.id]);
+
+  const onChangeTags = useCallback(
+    (arr: string[]) => {
+      setValue('tags', arr.join(','), { shouldDirty: true, shouldValidate: true });
+    },
+    [setValue],
+  );
+
+  const [initialTags, setInitialTags] = useState<string[] | undefined>();
+
+  const getEpigram = async (id: string) => {
+    const { data } = await axiosInstance.get(`/epigrams/${id}`);
+    return data;
+  };
+
+  const { data: detail, isLoading: isLoadingDetail } = useQuery({
+    queryKey: ['epigram', epigramId],
+    queryFn: () => getEpigram(epigramId as string),
+    enabled: !!epigramId,
+  });
+
+  useEffect(() => {
+    if (!detail) return;
+    const author = (detail.author ?? '').trim();
+    const authorMode = author === '알 수 없음' || author === '본인' ? author : '직접 입력';
+    const authorValue = authorMode === '직접 입력' ? author : '';
+
+    const names = toTagNames(detail.tags);
+    setInitialTags(names);
+    reset({
+      content: detail.content ?? '',
+      authorMode,
+      author: authorValue,
+      referenceTitle: detail.referenceTitle ?? '',
+      referenceUrl: detail.referenceUrl ?? '',
+      tags: names.join(','),
+    });
+  }, [detail, reset]);
+
+  const authorMode = watch('authorMode');
+
+  const createEpigram = useMutation({
+    mutationFn: async (data: EpigramRequestApi) => {
+      const { data: result } = await axiosInstance.post('/epigrams', data);
+      return result;
+    },
+  });
+
+  const updateEpigram = useMutation({
+    mutationFn: async (params: { id: string; body: EpigramRequestApi }) => {
+      const { data: result } = await axiosInstance.patch(`/epigrams/${params.id}`, params.body);
+      return result;
+    },
+  });
+
+  const toTagArray = (s?: string) =>
+    (s ?? '')
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean);
+
+  const onSubmit = async (data: EpigramForm) => {
+    const safeAuthor: string =
+      data.authorMode === '직접 입력' ? data.author?.trim() || '없음' : data.authorMode;
+
+    const tagsArr = toTagArray(data.tags);
+
+    const payload = {
+      content: data.content,
+      author: safeAuthor,
+      referenceTitle: data.referenceTitle || undefined,
+      referenceUrl: data.referenceUrl || undefined,
+      tags: tagsArr,
+    };
+
+    try {
+      if (epigramId) {
+        const updated = await updateEpigram.mutateAsync({ id: epigramId, body: payload });
+        const id = epigramId ?? updated?.id ?? updated?.epigramId;
+        alert('정상적으로 수정되었습니다.');
+        router.push(`/epigrams/${id}`);
+      } else {
+        const created = await createEpigram.mutateAsync(payload);
+        const id = created?.id ?? created?.epigramId;
+        alert('정상적으로 등록되었습니다.');
+        if (id) router.push(`/epigrams/${id}`);
+        else router.push('/epigrams');
+      }
+    } catch {
+      alert('오류가 발생했습니다.');
+    }
+  };
+
+  const { t } = useTranslation('editor');
+
+  return (
+    <div className="flex flex-col items-center pt-19 sm:pt-23 lg:pt-47 px-6 w-full">
+      <div className="max-w-[640px] w-full">
+        <p className="mb-6 w-full text-lg-sb md:text-xl-sb">{t('title')}</p>
+
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <div className="mb-10 w-full">
+            <p className="text-md-sb md:text-lg-sb">
+              {t('content')} <span className="text-error">*</span>
+            </p>
+            <textarea
+              className="py-[10px] px-4 w-full h-[132px] lg:h-[148px] border border-blue-300 rounded-[12px]
+            text-lg-r lg:text-xl-r placeholder-blue-400 text-black-950 caret-blue-400
+            resize-none outline-none
+            hover:border hover:border-blue-500 focus:border focus:border-blue-500"
+              maxLength={500}
+              placeholder={t('content_placeholder')}
+              {...register('content', {
+                required: '필수 항목입니다.',
+                maxLength: { value: 500, message: '500까지 작성 가능합니다.' },
+              })}
+              aria-invalid={!!errors.content}
+            />
+            {errors.content && (
+              <p className="mt-2 text-right text-sm-m text-error">{errors.content.message}</p>
+            )}
+          </div>
+
+          <div className="mb-10 w-full">
+            <p className="text-md-sb mb-2 md:text-lg-sb">
+              {t('author')} <span className="text-error">*</span>
+            </p>
+            <Controller
+              name="authorMode"
+              control={control}
+              rules={{ required: true }}
+              render={({ field }) => (
+                <RadioGroup
+                  name="저자 구분"
+                  value={field.value}
+                  onChange={field.onChange}
+                  options={[
+                    { label: t('enter_directly'), value: '직접 입력' },
+                    { label: t('unknown'), value: '알 수 없음' },
+                    { label: t('self'), value: '본인' },
+                  ]}
+                />
+              )}
+            />
+
+            {authorMode === '직접 입력' && (
+              <Input
+                placeholder={t('author_placeholder')}
+                {...register('author', {
+                  required: '저자 이름을 입력해 주세요.',
+                  maxLength: { value: 30, message: '30자 이하로 입력해 주세요.' },
+                })}
+                aria-invalid={!!errors.author}
+              />
+            )}
+            {errors.author && (
+              <p className="mt-2 text-right text-sm-m text-error">{errors.author.message}</p>
+            )}
+          </div>
+
+          <div className="mb-10 w-full">
+            <p className="text-md-sb mb-2 md:text-lg-sb">{t('source')}</p>
+            <Input
+              className="mb-2 lg:mb-4"
+              placeholder={t('source_placeholder')}
+              {...register('referenceTitle')}
+            />
+            <Input
+              placeholder="URL (ex. https://www.website.com)"
+              {...register('referenceUrl', {
+                pattern: {
+                  value: /^(https?:\/\/)?([\w-]+\.)+[\w-]{2,}(\/[^\s]*)?$/i,
+                  message: '유효한 URL 형식이 아닙니다.',
+                },
+              })}
+              aria-invalid={!!errors.referenceUrl}
+            />
+            {errors.referenceUrl && (
+              <p className="mt-2 text-right text-sm-m text-error">{errors.referenceUrl.message}</p>
+            )}
+          </div>
+
+          <div className="mb-10 w-full">
+            <p className="text-md-sb mb-2 md:text-lg-sb">{t('tag')}</p>
+            <input type="hidden" {...register('tags')} />
+            <TagInput onChangeTags={onChangeTags} initialTags={initialTags} />
+          </div>
+
+          <Button
+            size="2xl"
+            type="submit"
+            disabled={!isValid || isLoadingDetail}
+            className="w-full"
+          >
+            {t('submit')}
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default FeedForm;

--- a/src/type/feed.ts
+++ b/src/type/feed.ts
@@ -20,3 +20,20 @@ export interface Epigram {
   referenceUrl: string;
   referenceTitle: string;
 }
+
+export interface EpigramForm {
+  tags?: string;
+  referenceUrl?: string;
+  referenceTitle?: string;
+  authorMode: '직접 입력' | '알 수 없음' | '본인';
+  author: string;
+  content: string;
+}
+
+export type EpigramRequestApi = {
+  content: string;
+  author: string;
+  referenceTitle?: string;
+  referenceUrl?: string;
+  tags?: string[];
+};

--- a/src/utils/tags.ts
+++ b/src/utils/tags.ts
@@ -1,0 +1,6 @@
+export type TagLike = string | { id?: number | string; name?: string };
+
+export const toTagNames = (input?: TagLike[] | null): string[] =>
+  Array.isArray(input)
+    ? input.map((t) => (typeof t === 'string' ? t : (t?.name ?? ''))).filter(Boolean)
+    : [];


### PR DESCRIPTION
## 🔍 What

- 에피그램 만들기 기능 구현
- 에피그램 수정하기 기능 구현

## 📸 Screenshot (Optional)

### 만들기 페이지
<img width="699" height="837" alt="스크린샷 2025-09-01 오후 3 09 47" src="https://github.com/user-attachments/assets/31add87b-7e2b-4118-a2e9-fab72673f863" />

### 태그 추가 기능
<img width="676" height="139" alt="스크린샷 2025-09-01 오후 3 10 13" src="https://github.com/user-attachments/assets/c9289318-91bc-4ed0-8d8b-3c966187c454" />


## ✅ Checklist

- [x] 기능이 정상 동작함
- [x] 관련 문서 및 주석 최신화
- [x] 불필요한 콘솔/코드 제거
- [x] 코드 컨벤션에 맞게 작성됨

## 💬 Comment for Reviewer

- 자잘한 UI 수정이 필요합니다!
- /editor?id={아이디} 이러한 URL로 입력받으면 페이지로 이동하지만 수정하기 텍스트 변경이 필요합니다.
